### PR TITLE
Fix for deprecation: format is now fmt

### DIFF
--- a/scripts/examples/query_example.py
+++ b/scripts/examples/query_example.py
@@ -61,9 +61,9 @@ data = db.inventory('2MASS J13571237+1428398', pretty_print=True)
 print(type(data))
 
 # Search method
-db.search_object('twa 27', format='astropy')
-db.search_object('twa 27', format='astropy', resolve_simbad=True, output_table='Names')
-db.search_object('1357+1428', output_table='Photometry', format='astropy')
+db.search_object('twa 27', fmt='astropy')
+db.search_object('twa 27', fmt='astropy', resolve_simbad=True, output_table='Names')
+db.search_object('1357+1428', output_table='Photometry', fmt='astropy')
 
 # Delete a row
 for row in db.query(db.Photometry).all():

--- a/scripts/ingests/bdnyc_ingest_photometry.py
+++ b/scripts/ingests/bdnyc_ingest_photometry.py
@@ -47,7 +47,7 @@ source_dict = {}
 for i, row in sources.iterrows():
     bd_source = bdnyc.search_object(row['source'], output_table='sources',
                                     table_names={'sources': ['designation', 'names']},
-                                    format='pandas')
+                                    fmt='pandas')
     if len(bd_source) != 1:
         print(f"ERROR matching {row['source']}")
     else:

--- a/scripts/tutorials/generate_database.py
+++ b/scripts/tutorials/generate_database.py
@@ -21,8 +21,7 @@ create_database(connection_string)
 db = Database(connection_string)
 db.load_database(DB_PATH, verbose=False)
 
-print('New db file generated.')
-print(os.listdir())
+print('New database generated.')
 
 # Close all connections
 db.session.close()

--- a/tests/test_integrity.py
+++ b/tests/test_integrity.py
@@ -98,7 +98,7 @@ def test_source_names(db):
     # Verify that all sources have at least one entry in Names table
     sql_text = "SELECT Sources.source	FROM Sources LEFT JOIN Names " \
              "ON Names.source=Sources.source WHERE Names.source IS NULL"
-    missing_names = db.sql_query(sql_text, format='astropy')
+    missing_names = db.sql_query(sql_text, fmt='astropy')
     assert len(missing_names) == 0
 
 
@@ -111,7 +111,7 @@ def test_source_uniqueness(db):
     # Another method to find the duplicates
     sql_text = "SELECT Sources.source FROM Sources GROUP BY source " \
                "HAVING (Count(*) > 1)"
-    duplicate_names = db.sql_query(sql_text, format='astropy')
+    duplicate_names = db.sql_query(sql_text, fmt='astropy')
 
     # if duplicate_names is non_zero, print out duplicate names
     if len(duplicate_names) > 0:
@@ -163,7 +163,7 @@ def test_source_uniqueness2(db):
     # Verify that all Sources.source values are unique and find the duplicates
     sql_text = "SELECT Sources.source FROM Sources GROUP BY source " \
                "HAVING (Count(*) > 1)"
-    duplicate_names = db.sql_query(sql_text, format='astropy')
+    duplicate_names = db.sql_query(sql_text, fmt='astropy')
     # if duplicate_names is non_zero, print out duplicate names
     assert len(duplicate_names) == 0
 
@@ -192,7 +192,7 @@ def test_source_simbad(db):
             continue
 
         # Examine DB for each input, displaying results when more than one source matches
-        t = db.search_object(simbad_names, output_table='Sources', format='astropy', fuzzy_search=False)
+        t = db.search_object(simbad_names, output_table='Sources', fmt='astropy', fuzzy_search=False)
         if len(t) > 1:
             print(f'Multiple matches for {name}: {simbad_names}')
             print(db.query(db.Names).filter(db.Names.c.source.in_(t['source'])).astropy())


### PR DESCRIPTION
The latest dev version of Astrodbkit2 replaces `format` with `fmt` in its calls. This is to avoid using the built-in name `format`. 
Using `format`  will work but will throw `DeprecationWarning` until it is retired in the next official release.