### PR TITLE
Add search functionality to the same page

### DIFF
--- a/website/splash_table.py
+++ b/website/splash_table.py
@@ -4,6 +4,8 @@ Generates the whole database as a table on page
 
 Methods
 -------
+Qry
+    For the query string check
 make_table
     Creates the columndatasource and datatable (bokeh objects) using query of sources
 main
@@ -15,6 +17,14 @@ import numpy as np
 
 # local libs
 from web_base import load_db
+
+
+class Qry:
+    def __init__(self, instr: str):
+        if instr == 'notanobject':
+            self.default = True
+        else:
+            self.default = False
 
 
 def make_table(results: list):
@@ -53,6 +63,29 @@ def make_table(results: list):
     return cds, dt
 
 
+def querying(qrystr: str = 'notanobject'):
+    """
+    Queries the database for an object
+
+    Parameters
+    ----------
+    qrystr
+        The partial string of an object
+
+    Returns
+    -------
+    The list of tuples of object info
+    """
+    qry = Qry(qrystr)
+    db = load_db()  # load the database
+    results = db.search_object(qrystr)
+    if qry.default:
+        return results
+    else:
+        results = [obj[:3] for obj in results]
+        return results
+
+
 def main():
     """
     Main module, queries database and returns the resultant table
@@ -64,10 +97,7 @@ def main():
     dt
         DataTable, the bokeh object to be displayed on page
     """
-    db = load_db()  # load the database
-    # TODO: what about when there are tonnes of objects, need to cut up table or have searching implemented
-    # TODO: a callback on the dt object to parse the next X sources
-    results = db.query(db.Sources).all()  # query all the sources into one list
+    results = querying()
     cds, dt = make_table(results)  # create the bokeh elements
     return cds, dt
 

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -34,14 +34,6 @@
     <!-- Font Awesome v.5.0.12 -->
     <link rel="stylesheet" href="/static/css/all.css" crossorigin="anonymous">
 
-    <!-- jquery datatable -->
-    <script src="/static/js/jquery.dataTables.min.js"
-            crossorigin="anonymous">
-    </script>
-    <script src="/static/css/jquery.dataTables.min.css"
-            crossorigin="anonymous">
-    </script>
-
     <!-- Custom CSS Styling -->
     <style>
         /* reset */
@@ -77,8 +69,13 @@
     <!-- header box -->
     <div id="header" style="width: 100%; height: 100px; background-color: deepskyblue;
      padding-bottom: 10px;">
-        <h1 style="color: floralwhite; position: relative; top: 45%; left: 45% ; width: 95%; font-size: xx-large">
+        <h1 style="color: floralwhite; position: relative; top: 45%; left: 35% ; width: 85%; font-size: xx-large">
             Simple Browser</h1>
+        <div id="searchButton" style="width: 10%; position: absolute; right: 20%; display: none">
+            {%- block searchbutton -%}
+            {{ embed(roots.searchbutton) }}
+            {%- endblock -%}
+        </div>
     </div>
 
     <!-- Following two divs are to get the content blocks centrally aligned on the page, under the header box -->
@@ -119,11 +116,15 @@
                 {{ embed(roots.datatable) }}
                 {%- endblock -%}
             </div>
-            <script>
-            $(document).ready( function () {
-                $('#fullTable').DataTable();
-            } );
-            </script>
+        </div>
+    </div>
+
+    <div id="searchWrapper" style="position: absolute; top: 110px; width: 100%; text-align: center;
+     height: 740px; background-color: darkslateblue; overflow-y: hidden; z-index: 3">
+        <div id="searchBar" style="display: inline-block; width: 40%; top: 45%; font-size: large; position: relative">
+            {%- block searchbar -%}
+            {{ embed(roots.searchbar) }}
+            {%- endblock -%}
         </div>
     </div>
     {%- endblock -%}

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -117,15 +117,24 @@
                 {%- endblock -%}
             </div>
         </div>
-    </div>
 
-    <div id="searchWrapper" style="position: absolute; top: 110px; width: 100%; text-align: center;
-     height: 740px; background-color: darkslateblue; overflow-y: hidden; z-index: 3">
-        <div id="searchBar" style="display: inline-block; width: 40%; top: 45%; font-size: large; position: relative">
-            {%- block searchbar -%}
-            {{ embed(roots.searchbar) }}
-            {%- endblock -%}
+        <div id="searchWrapper" style="position: absolute; top: 110px; width: 100%; text-align: center;
+         height: 740px; background-color: darkslateblue; overflow-y: hidden; z-index: 3; display: block">
+            <div id="searchBar" style="display: inline-block; width: 40%; top: 45%; font-size: large; position: relative">
+                {%- block searchbar -%}
+                {{ embed(roots.searchbar) }}
+                {%- endblock -%}
+            </div>
         </div>
+        <script>
+            setInterval(searchBarFocus, 2000);
+            function searchBarFocus() {
+                console.log(document.getElementById("searchWrapper").style.display);
+                if (document.getElementById("searchWrapper").style.display === 'block') {
+                    document.getElementsByName("searchbar")[0].focus();
+                }
+            }
+        </script>
     </div>
     {%- endblock -%}
 </body>


### PR DESCRIPTION
Stopped bokeh warning about column data source columns.
Created callback enabled front facing div to hide/ unhide with the search functionality on
Searches using db.search_object so partial strings
That will update the main table on key press; on non-focus to search box (enter or click away) the search div will vanish, it'll come back if you click the button on the top.

Still ugly css as haven't had the time to play with that too much. Should be able to style bokeh elements and surroundings. Jinja2 still messing up the css.

Still call as ```bokeh serve --show website/``` from top directory.